### PR TITLE
Pass current filename to credo

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -53,7 +53,7 @@ lint = (editor) ->
 
   cwd = projectPath(editor)
   userFlags = atom.config.get('linter-elixir-credo.flags').split(' ')
-  args = ['credo'].concat(userFlags).concat(['--read-from-stdin', '--format', 'flycheck'])
+  args = ['credo'].concat(userFlags).concat(['--read-from-stdin', editor.getPath(), '--format', 'flycheck'])
   helpers.exec(atom.config.get('linter-elixir-credo.executablePath'), args, {cwd, stdin, stream}).then (result) ->
     ParseOutput(editor, result)
 


### PR DESCRIPTION
Credo sometimes defines a different behaviour for `.exs` files, e.g. https://github.com/rrrene/credo/blob/master/lib/credo/check/readability/module_doc.ex#L39